### PR TITLE
Add Aigis — zero-dep Python firewall for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 - [**Acgs-lite**](https://github.com/dislovelhl/acgs-lite): Governance layer for AI agents that blocks unsafe actions before execution, enforces MACI separation of powers, and keeps tamper-evident audit trails. ![GitHub Repo stars](https://img.shields.io/github/stars/dislovelhl/acgs-lite?style=social)
 - [**Prompt Shield**](https://github.com/markmishaev76/Prompt-Shield): GitHub Action for detecting indirect prompt injection in CI/CD pipelines. 4-layer defense architecture. ![GitHub Repo stars](https://img.shields.io/github/stars/markmishaev76/Prompt-Shield?style=social)
 - [AIDEFEND](https://edward-playground.github.io/aidefense-framework/): Practical knowledge base for AI security defenses
+- [**Aigis**](https://github.com/killertcell428/aigis): Zero-dependency Python firewall for AI agents. 180+ patterns across OWASP LLM Top 10, StruQ-style structured prompts, goal-conditioned FSM, RAG context filter, MCP 3-stage scanning, MemoryGraft defence, judge-manipulation detection. Multi-layer: 4 walls + L4-L7 capability/AEP/safety/FSM. ![GitHub stars](https://img.shields.io/github/stars/killertcell428/aigis?style=social)
 
 ---
 


### PR DESCRIPTION
Adds [Aigis](https://github.com/killertcell428/aigis) to the **🛡️ Defensive & Guardrail Tools** section.

### Why it fits

Aigis v0.0.4 (released today) is a zero-dependency Python library covering several of the categories already tracked in this list:

- Defensive & Guardrail (this section) — 4-wall multi-layer defence + L4-L7 deep layers (capability ACC, atomic execution pipeline, safety verifier, goal-conditioned FSM)
- RAG Security — `filters.rag_context_filter` applies DataFilter / RAGDefender-style strip/block on retrieved chunks
- MCP & Agent — `mcp_scanner` covers MSB 3-stage classification (discovery / invocation / response)
- Prompt Injection — 180+ patterns across OWASP LLM Top 10, plus the new `judge_manipulation` category (15 patterns) for LLM-as-Judge bypass defence

### Recent research, implemented as modules

Each ships in the zero-dep core, one module per paper:

- Mirror Design Pattern (arxiv:2603.11875, Mar 2026) — char-trigram fast screen
- StruQ (arxiv:2402.06363) + LLMail-Inject (arxiv:2506.09956) — structured_query
- MI9 (arxiv:2508.03858, Aug 2025) — goal-conditioned FSM (spec_lang.fsm)
- MemoryGraft (arxiv:2512.16962, Dec 2025) — memory-imitation detector
- MSB (arxiv:2510.15994, Oct 2025) — 3-stage MCP scanning
- DataFilter (arxiv:2510.19207) + RAGDefender (arxiv:2511.01268) — rag_context_filter
- AdvJudge-Zero (Palo Alto Unit 42, 2026) — judge_manipulation patterns

### Footprint

- Zero Python dependencies (stdlib only)
- One-line middleware for FastAPI / LangChain / LangGraph / OpenAI / Anthropic / MCP
- 940+ tests passing, public self-audit in v0.0.4 CHANGELOG
- Apache 2.0

If you prefer to place it in **MCP & Agent Scanners** or **RAG Security** instead of / in addition to Defensive & Guardrail, happy to adjust.