### PR TITLE
Add llm-security-scanner to Multi-Purpose Model Scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 - ![GitHub stars](https://img.shields.io/github/stars/RomiconEZ/LLaMator?style=social) [**LLaMator**](https://github.com/RomiconEZ/LLaMator) Framework for testing vulnerabilities of LLMs
 - ![GitHub Repo stars](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=social) [**Plexiglass**](https://github.com/kortex-labs/plexiglass) Security toolbox for testing and safeguarding LLMs
 - ![GitHub Repo stars](https://img.shields.io/github/stars/inkog-io/inkog?style=social) [**Inkog**](https://github.com/inkog-io/inkog) AI agent security scanner (CLI + MCP server) detects prompt injection, SQLi via LLM.
+- [![GitHub Repo stars](https://img.shields.io/github/stars/tugkanboz/llm-security-scanner?style=social)](https://github.com/tugkanboz/llm-security-scanner) [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) Red-team toolkit for LLM apps — prompt injection, jailbreak & data exfiltration scanner with OWASP LLM Top 10 alignment and first-class Turkish payload support.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 - ![GitHub stars](https://img.shields.io/github/stars/RomiconEZ/LLaMator?style=social) [**LLaMator**](https://github.com/RomiconEZ/LLaMator) Framework for testing vulnerabilities of LLMs
 - ![GitHub Repo stars](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=social) [**Plexiglass**](https://github.com/kortex-labs/plexiglass) Security toolbox for testing and safeguarding LLMs
 - ![GitHub Repo stars](https://img.shields.io/github/stars/inkog-io/inkog?style=social) [**Inkog**](https://github.com/inkog-io/inkog) AI agent security scanner (CLI + MCP server) detects prompt injection, SQLi via LLM.
-- [![GitHub Repo stars](https://img.shields.io/github/stars/tugkanboz/llm-security-scanner?style=social)](https://github.com/tugkanboz/llm-security-scanner) [llm-security-scanner](https://github.com/tugkanboz/llm-security-scanner) Red-team toolkit for LLM apps — prompt injection, jailbreak & data exfiltration scanner with OWASP LLM Top 10 alignment and first-class Turkish payload support.
+- ![GitHub Repo stars](https://img.shields.io/github/stars/tugkanboz/llm-security-scanner?style=social) [**llm-security-scanner**](https://github.com/tugkanboz/llm-security-scanner) Red-team toolkit for LLM apps — prompt injection, jailbreak & data exfiltration scanner with OWASP LLM Top 10 alignment and first-class Turkish payload support.
 
 ---
 


### PR DESCRIPTION
Adds **llm-security-scanner** under "🧰 Multi-Purpose Model Scanners".

### What it is
Open-source red-team toolkit for testing LLM applications against 
prompt injection, jailbreaks, data exfiltration, and tool abuse.

### Why it might fit the list
- **OWASP LLM Top 10 alignment**: every payload tagged with its 
  corresponding LLM01-LLM10 category
- **First-class Turkish payload library**: a gap not covered by Garak 
  or promptfoo; serves the Turkish-speaking developer community
- **Pluggable architecture**: Target, Evaluator, and Reporter protocols, 
  with no platform lock-in
- **Provider-agnostic**: Anthropic, OpenAI, Ollama, generic HTTP
- **CI-ready**: exits non-zero on findings, outputs Markdown, JSON, or SARIF

Happy to adjust the description, category, or order if you'd 
prefer a different placement.