### PR TITLE
Add Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 ### 🤖 MCP & Agent Scanners
 
 - ![GitHub stars](https://img.shields.io/github/stars/THUDM/AgentBench?style=social) [**AgentBench**](https://github.com/THUDM/AgentBench): Benchmark to evaluate LLMs as agents
+- ![GitHub Repo stars](https://img.shields.io/github/stars/ArmorerLabs/Armorer-Guard?style=social) [**Armorer Guard**](https://github.com/ArmorerLabs/Armorer-Guard) Local Rust scanner for AI-agent prompt injection, credential redaction, sensitive-data requests, exfiltration-style text, and dangerous tool-call context
 - ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social) [**Agentic Radar**](https://github.com/splx-ai/agentic-radar) Open-source CLI security scanner for agentic workflows
 - ![GitHub Repo stars](https://img.shields.io/github/stars/cisco-ai-defense/mcp-scanner?style=social) [**MCP Scanner**](https://github.com/cisco-ai-defense/mcp-scanner) Scan MCP servers for potential threats & security findings
 - ![GitHub stars](https://img.shields.io/github/stars/Puliczek/awesome-mcp-security?style=social) [**Awesome MCP Security**](https://github.com/Puliczek/awesome-mcp-security) Curated list of MCP security resources

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 ### 🤖 MCP & Agent Scanners
 
 - ![GitHub stars](https://img.shields.io/github/stars/THUDM/AgentBench?style=social) [**AgentBench**](https://github.com/THUDM/AgentBench): Benchmark to evaluate LLMs as agents
-- ![GitHub Repo stars](https://img.shields.io/github/stars/ArmorerLabs/Armorer-Guard?style=social) [**Armorer Guard**](https://github.com/ArmorerLabs/Armorer-Guard) Local Rust scanner for AI-agent prompt injection, credential redaction, sensitive-data requests, exfiltration-style text, and dangerous tool-call context
 - ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social) [**Agentic Radar**](https://github.com/splx-ai/agentic-radar) Open-source CLI security scanner for agentic workflows
 - ![GitHub Repo stars](https://img.shields.io/github/stars/cisco-ai-defense/mcp-scanner?style=social) [**MCP Scanner**](https://github.com/cisco-ai-defense/mcp-scanner) Scan MCP servers for potential threats & security findings
 - ![GitHub stars](https://img.shields.io/github/stars/Puliczek/awesome-mcp-security?style=social) [**Awesome MCP Security**](https://github.com/Puliczek/awesome-mcp-security) Curated list of MCP security resources
@@ -57,6 +56,7 @@ A curated list of awesome tools, documents, and projects about LLM Security.
 - ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social) [**Ziran**](https://github.com/taoq-ai/ziran) Security testing framework for AI agents
 - ![GitHub Repo stars](https://img.shields.io/github/stars/Odingard/cerberus?style=social) [**Cerberus**](https://github.com/Odingard/cerberus) Agentic AI runtime security platform
 - ![GitHub Repo stars](https://img.shields.io/github/stars/NeuZhou/clawguard?style=social) [**clawguard**](https://github.com/NeuZhou/clawguard) Firewall for AI agents
+- ![GitHub Repo stars](https://img.shields.io/github/stars/ArmorerLabs/Armorer-Guard?style=social) [**Armorer Guard**](https://github.com/ArmorerLabs/Armorer-Guard) Local Rust scanner for AI-agent prompt injection and dangerous tool-call context
 - ![GitHub Repo stars](https://img.shields.io/github/stars/razashariff/mcps-audit?style=social) [**MCPs-audit**](https://github.com/razashariff/mcps-audit) OWASP Security Scanner for MCP Servers
 - ![GitHub Repo stars](https://img.shields.io/github/stars/Aveerayy/agent-guard?style=social) [**Agent Guard**](https://github.com/Aveerayy/agent-guard) Runtime governance firewall for AI agents, policy enforcement, MCP tool scanning
 


### PR DESCRIPTION
Adds Armorer Guard, a local Rust scanner for AI-agent prompt injection, credential redaction, sensitive-data requests, exfiltration-style text, and dangerous tool-call context.\n\nRepo: https://github.com/ArmorerLabs/Armorer-Guard\nDemo: https://huggingface.co/spaces/armorer-labs/armorer-guard-demo