### PR TITLE
Add Tuning Engines LLM security controls entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 - [AIDEFEND](https://edward-playground.github.io/aidefense-framework/): Practical knowledge base for AI security defenses
 - [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): Reference implementation for ASI06 (Memory Poisoning). Runtime defense for LLM agent memory.
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
+- [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics, runtime state references, and outcomes
 
 ---
 


### PR DESCRIPTION
Adds Tuning Engines to Defensive & Guardrail Tools. The fit is runtime controls for governed model, MCP, skill, and agent traffic, including guardrails, policy decisions, approvals, traces, cost analytics, state references, and outcomes.