### PR TITLE
feat: add TWZRD Agent Intel — on-chain agent identity verification for MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social) [**Ziran**](https://github.com/taoq-ai/ziran) Security testing framework for AI agents
 - ![GitHub Repo stars](https://img.shields.io/github/stars/razashariff/mcps-audit?style=social) [**MCPs-audit**](https://github.com/razashariff/mcps-audit) OWASP Security Scanner for MCP Servers
 - ![GitHub Repo stars](https://img.shields.io/github/stars/Aveerayy/agent-guard?style=social) [**Agent Guard**](https://github.com/Aveerayy/agent-guard) Runtime governance firewall for AI agents, policy enforcement, MCP tool scanning
+- [**TWZRD Agent Intel**](https://intel.twzrd.xyz) On-chain trust scoring for AI agent wallet identity on Solana. Verify agent identity before allowing access to MCP tools or executing actions — free `preflight_check(wallet)` + paid Ed25519-signed trust receipt via x402. MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP & Agent Scanners** section
- Before an AI agent can access MCP tools or execute actions, verify its wallet identity with on-chain Solana trust scoring
- Free: `preflight_check(wallet)` — trust score from on-chain agent activity
- Paid: `get_trust_receipt(wallet)` — Ed25519-signed V5 trust receipt via x402 micropayment (<\$0.01, <1s)
- MCP config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

## Why it fits

This list covers MCP scanners and agent security. TWZRD is the identity layer: it answers "is this agent wallet who it claims to be before I let it call my MCP tools?" Complements policy enforcement tools (Agent Guard, Agentic Radar) with pre-dispatch identity verification.

## Test plan

- [ ] Link: https://intel.twzrd.xyz
- [ ] MCP: https://intel.twzrd.xyz/mcp