### PR TITLE
PI Detector Bench - 2-axis prompt injection benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - ![GitHub stars](https://img.shields.io/github/stars/EasyJailbreak/EasyJailbreak?style=social) [**PALLMs (Payloads for Attacking Large Language Models)**](https://github.com/mik0w/pallms)
 - ![GitHub stars](https://img.shields.io/github/stars/lakeraai/pint-benchmark?style=social) [**Lakera PINT Benchmark**](https://github.com/lakeraai/pint-benchmark): Benchmark for prompt injection detection
 - ![GitHub stars](https://img.shields.io/github/stars/pdparchitect/llm-hacking-database?style=social) [**LLM Hacking Database**](https://github.com/pdparchitect/llm-hacking-database): Attacks against LLMs
+- ![GitHub stars](https://img.shields.io/github/stars/bastion-soft/pi-detector-bench?style=social) [**PI Detector Bench**](https://github.com/bastion-soft/pi-detector-bench): Two axis prompt-injection benchmark - detection rate AND false positives
 
 ---
 


### PR DESCRIPTION
### What this adds
Adding PI Detector Bench under 🕵️ Benchmarks

Prompt injection detector filter AUC value alone doesn't tell you what threshold rate is optimal or if the false positive rate is acceptable. This benchmark is an open-source (MIT) test harness that benchmarks multiple different prompt-injection detectors/filters against various datasets - attack and benign. It scores both the catch-rate and the false-positive-rate at all threshold values, so it's evident which operating point is optimal for what detector.

### Why it fits this section

It's a benchmark for prompt-injection detectors, repeatable, MIT-licensed, actively maintained, keeps adding new prompt-injection detectors.

### Repo
https://github.com/bastion-soft/pi-detector-bench

### Entry added
- ![GitHub stars](https://img.shields.io/github/stars/bastion-soft/pi-detector-bench?style=social) [**PI Detector Bench**](https://github.com/bastion-soft/pi-detector-bench): Two axis prompt-injection benchmark - detection rate AND false positives

### Checklist
 Open source (MIT) and actively maintained
 Added under the most relevant section
 Entry matches the existing format

### Authorship

I am the contributor of this project.