### PR TITLE
Add Phinq to Defensive & Guardrail Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard): Reference implementation for ASI06 (Memory Poisoning). Runtime defense for LLM agent memory.
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
 - [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics
+- ![GitHub Repo stars](https://img.shields.io/github/stars/phinq-co/phinq?style=social) [**Phinq**](https://github.com/phinq-co/phinq): Governance proxy for autonomous AI agents — deterministic tool-call risk classification, holds dangerous/irreversible actions for human approval, tamper-evident hash-chained audit log
 
 ---
 


### PR DESCRIPTION
Adding [Phinq](https://github.com/phinq-co/phinq), an open-source (MIT) governance proxy for autonomous AI agents, to the **Defensive & Guardrail Tools** section.

Phinq sits between an agent and its LLM provider, classifies every tool call with a deterministic risk engine, holds dangerous/irreversible actions for human approval, and writes a hash-chained, tamper-evident audit log — complementary to the firewall/guardrail tools already listed (e.g. AI Security Gateway, TrustGate, Acgs-lite). Thanks for maintaining the list!