### PR TITLE
Add fpverify: detect silent model substitution by API relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - ![GitHub Repo stars](https://img.shields.io/github/stars/kortex-labs/plexiglass?style=social) [**Plexiglass**](https://github.com/kortex-labs/plexiglass) Security toolbox for testing and safeguarding LLMs
 - ![GitHub Repo stars](https://img.shields.io/github/stars/inkog-io/inkog?style=social) [**Inkog**](https://github.com/inkog-io/inkog) AI agent security scanner (CLI + MCP server) detects prompt injection, SQLi via LLM
 - ![GitHub Repo stars](https://img.shields.io/github/stars/tugkanboz/llm-security-scanner?style=social) [**LLM Security Scanner**](https://github.com/tugkanboz/llm-security-scanner) Prompt injection with OWASP LLM Top 10 and Turkish payloads
+- ![GitHub Repo stars](https://img.shields.io/github/stars/Mohamed7415/fpverify?style=social) [**fpverify**](https://github.com/Mohamed7415/fpverify) Behavioral-fingerprint auditor that detects silent model substitution by API relays (anytime-valid sequential test, FPR ≤ 1%)
 
 ---
 


### PR DESCRIPTION
Adds [fpverify](https://github.com/Mohamed7415/fpverify) (MIT) to Multi-Purpose Model Scanners.

fpverify audits any OpenAI-compatible endpoint for silent model substitution ('you pay for the flagship, the relay serves a cheaper clone'). It uses single-token behavioral fingerprints - LLMs cannot answer 'pick a random number' randomly, and each model's bias pattern is stable - plus a sequential anytime-valid betting test that caps the false-positive rate at 1% at any stopping point. Blatant swaps are caught in ~15 one-token queries (~USD 0.002).

Extras that may interest this list's audience: a 9-adversary red-team simulator, a July-2026 fingerprint study of 9 frontier models (raw data + one-command reproduction), a 4-round red/blue co-evolution analysis documenting where detection provably breaks, and a community reference-fingerprint library with an anti-poisoning contribution protocol.

Entry follows the section format (stars badge + bold link + one-line description).