### PR TITLE
Add SourceryKit to Agent Authorization & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@
 
 - ![GitHub stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social) [**Tenuo**](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents
 - ![GitHub Repo stars](https://img.shields.io/github/stars/lelu-ai/lelu?style=social) [**Lelu**](https://github.com/lelu-ai/lelu): Authorization engine gating agent tool calls on policy and prompt injection
+- ![GitHub Repo stars](https://img.shields.io/github/stars/ProvablyAI/sourcerykit?style=social) [**SourceryKit**](https://github.com/ProvablyAI/sourcerykit): Verifies agent HTTP/MCP calls against a trusted source with ZK proofs and allow-list blocking
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
 - [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics
-- ![GitHub Repo stars](https://img.shields.io/github/stars/ProvablyAI/sourcerykit?style=social) [**SourceryKit**](https://github.com/ProvablyAI/sourcerykit): Verifies an agent's outbound HTTP and MCP calls against a source of truth with zero-knowledge proofs, then blocks anything off the trusted-endpoint allow-list and logs each call
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - ![GitHub Repo stars](https://img.shields.io/github/stars/lelu-ai/lelu?style=social) [**Lelu**](https://github.com/lelu-ai/lelu): Authorization engine gating agent tool calls on policy and prompt injection
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
 - [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics
+- ![GitHub Repo stars](https://img.shields.io/github/stars/ProvablyAI/sourcerykit?style=social) [**SourceryKit**](https://github.com/ProvablyAI/sourcerykit): Verifies an agent's outbound HTTP and MCP calls against a source of truth with zero-knowledge proofs, then blocks anything off the trusted-endpoint allow-list and logs each call
 
 ---
 


### PR DESCRIPTION
Hi, this list is well put together, the Agent Authorization & Governance section especially. Added SourceryKit there, next to APort and Tenuo.

It's a Python SDK that verifies an agent's outbound HTTP and MCP calls against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It blocks anything off the trusted-endpoint allow-list and logs each call. Source-available under BSL 1.1, with a hosted backend for the proof check.

Kept it to one line in your format. The repo is ~15 stars, so it fits the README threshold rather than emerging.md. Thanks for taking a look.