### PR TITLE
Add Penholder to Agent Authorization & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 - ![GitHub Repo stars](https://img.shields.io/github/stars/ProvablyAI/sourcerykit?style=social) [**SourceryKit**](https://github.com/ProvablyAI/sourcerykit): Verifies agent HTTP/MCP calls against a trusted source with ZK proofs and allow-list blocking
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
 - [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics
+- [Penholder](https://penholder.ai/): Preventive human-approval write-gate — an agent's write to a database or system of record lands PENDING and commits only after a human approves, fail-closed on conflict, with a tamper-evident provenance log
 
 ---
 


### PR DESCRIPTION
Adds **Penholder** to 🔐 Agent Authorization & Governance.

Penholder is a preventive human-approval **write-gate**: an AI agent's write to a database or system of record lands PENDING and commits only after a human approves — fail-closed on conflict, with a tamper-evident provenance log. It differs from the tool-call-level authorization tools in this subsection by gating at the **system-of-record commit** rather than the agent's tool call, so a held write survives process/framework restarts and is re-checked against live state at approve time. Placed alongside the other hosted entries (APort, Tuning Engines).

Single entry, hosted (no public repo), formatted to match the existing non-badge entries.

Disclosure: I'm affiliated with Penholder. Happy to adjust placement or wording.