### PR TITLE
Add correctover-scan — MCP config security scanner CLI (emerging)

### DIFF
--- a/emerging.md
+++ b/emerging.md
@@ -18,6 +18,7 @@ These stay visible for discovery while they gain traction. On periodic review th
 - ![GitHub Repo stars](https://img.shields.io/github/stars/sunglasses-dev/sunglasses?style=social) [**Sunglasses**](https://github.com/sunglasses-dev/sunglasses): Runtime trust scanner for AI agents covering prompt injection, tool poisoning, and MCP attacks
 - ![GitHub Repo stars](https://img.shields.io/github/stars/razashariff/mcps-audit?style=social) [**MCPs-audit**](https://github.com/razashariff/mcps-audit) OWASP Security Scanner for MCP Servers
 - ![GitHub Repo stars](https://img.shields.io/github/stars/Aveerayy/agent-guard?style=social) [**Agent Guard**](https://github.com/Aveerayy/agent-guard) Runtime governance firewall for AI agents, policy enforcement, MCP tool scanning
+- ![GitHub Repo stars](https://img.shields.io/github/stars/Correctover/correctover-scan?style=social) [**correctover-scan**](https://github.com/Correctover/correctover-scan): CLI that scans MCP client config files (Claude Desktop, Cursor, VS Code) for credential exposure, SSRF and missing auth/transport encryption; SARIF output for CI
 - ![GitHub Repo stars](https://img.shields.io/github/stars/MAUROCERON/ai-agent-security-mini-audit?style=social) [**AI Agent Risk Self-Check**](https://github.com/MAUROCERON/ai-agent-security-mini-audit): Browser self-check for AI-agent workflow risks (OWASP/NIST mapping)
 
 ### 💣 Prompt Injection


### PR DESCRIPTION
Adds [correctover-scan](https://github.com/Correctover/correctover-scan) to `emerging.md` under **MCP & Agent Scanners** (the project is new with under 10 GitHub stars, so emerging per the contributing guide).

What it is: a zero-config npm CLI (`npx correctover-scan`) that scans MCP client configuration files for security issues — credential exposure, SSRF, missing authentication/TLS, timeouts and audit logging — with findings mapped to OWASP AISVS and JSON/SARIF output.

Why it fits: the section lists scanners for agents, MCP servers and agentic workflows (e.g. Agentic Radar, MCP Shield, Repo Forensics); this scans MCP client-side configuration in the same defensive-tooling category.

Entry follows the documented format (stars badge matching the link, one-line description). Disclosure: I maintain the project (MIT-licensed).