### PR TITLE
Add Bifrost to defensive guardrail tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 
 ### 🛡️ Defensive & Guardrail Tools
 
+- ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social) [**Bifrost**](https://github.com/maximhq/bifrost): AI gateway with guardrails, rate limits, and access controls for governed model and MCP traffic
 - ![GitHub Repo stars](https://img.shields.io/github/stars/guardrails-ai/guardrails?color=gold) [**Guardrails**](https://github.com/guardrails-ai/guardrails): Add structured validation and policy enforcement for LLMs
 - ![GitHub stars](https://img.shields.io/github/stars/NVIDIA/NeMo-Guardrails?style=social) [**NeMo Guardrails**](https://github.com/NVIDIA-NeMo/Guardrails): Protects against jailbreak and hallucinations with customizable rulesets
 - ![GitHub Repo stars](https://img.shields.io/github/stars/facebookresearch/PurpleLlama?style=social) [**PurpleLlama**](https://github.com/facebookresearch/PurpleLlama): Tools to assess and improve LLM security from META


### PR DESCRIPTION
## Summary
- add Bifrost to Defensive & Guardrail Tools

Bifrost is placed in this section because its open-source gateway exposes guardrails, rate limits, and access controls for model and MCP traffic. The entry follows the repository’s GitHub badge format and remains within one line.

The change is limited to one README entry.