### PR TITLE
Add Vetto: daemon-less kernel sandbox for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [APort](https://aport.io/): Runtime policy and verification layer for AI agents and MCP-connected tools
 - [Tuning Engines](https://www.tuningengines.com/): AI control and evidence layer for governed model, MCP, skill, and agent traffic with guardrails, policy decisions, approvals, traces, cost analytics
 - [Penholder](https://penholder.ai/): Human-approval write-gate holding agent database writes pending until a human commits
+- ![GitHub stars](https://img.shields.io/github/stars/shleder/vetto?style=social) [**Vetto**](https://github.com/shleder/vetto): Daemon-less kernel sandbox for AI coding agents (Landlock/seccomp on Linux, Seatbelt on macOS) — denies secret reads and off-allowlist egress by default
 
 ---
 


### PR DESCRIPTION
Adds Vetto (https://github.com/shleder/vetto, Apache-2.0): daemon-less kernel sandbox for AI coding agents — `vetto enable <agent>` wraps 20 CLIs (Claude Code, Codex, Gemini, Aider, Cursor, …) with Landlock/seccomp isolation, egress allowlists and Git Guard.

Disclosure: I am the author/maintainer of Vetto.
